### PR TITLE
ゲストログイン編集不可一旦解除

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,13 +3,13 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
-  before_action :check_guest, only: %i[update destroy]
+  # before_action :check_guest, only: %i[update destroy]
 
-  def check_guest
-    if resource.email == 'guest@example.com'
-      redirect_to root_path, alert: 'ゲストユーザーの変更・削除はできません。'
-    end
-  end
+  # def check_guest
+  #   if resource.email == 'guest@example.com'
+  #     redirect_to root_path, alert: 'ゲストユーザーの変更・削除はできません。'
+  #   end
+  # end
 
   def after_sign_in_path_for(resource)
     user_path(resource)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!
-  before_action :check_guest, only: %i[update destroy]
+  # before_action :check_guest, only: %i[update destroy]
 
   def index
     @q = User.ransack(params[:q])


### PR DESCRIPTION
変更
ゲストログインのプロフィールを編集するため編集不可のバリデーションを一旦解除